### PR TITLE
マイページ画面のエラーの修正

### DIFF
--- a/app/assets/stylesheets/_common.scss
+++ b/app/assets/stylesheets/_common.scss
@@ -215,4 +215,5 @@ nav ul li a:hover {
 
 .card .card-action a:not(.btn):not(.btn-large):not(.btn-small):not(.btn-large):not(.btn-floating) {
   color: #757575;
+  text-transform: none;
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,8 +30,8 @@ class UsersController < ApplicationController
 
   def set_instances
     @user = User.find(params[:id])
-    @user_ic = @user.ic_image.present? ? @user.ic_image.url : '/assets/slider03.jpg'
-    @user_bg = @user.bg_image.present? ? @user.bg_image.url : '/assets/user_bg_image_basic.jpg'
+    @user_ic = @user.ic_image.present? ? @user.ic_image.url : 'https://s3-ap-northeast-1.amazonaws.com/upload-blogapp2/uploads/user/ic_image/1/slider03.jpg'
+    @user_bg = @user.bg_image.present? ? @user.bg_image.url : 'https://s3-ap-northeast-1.amazonaws.com/upload-blogapp2/uploads/user/bg_image/1/user_bg_image_basic.jpg'
     @post_articles = @user.articles.includes(:user).order('created_at DESC')
     @favorite_articles = @user.articles.includes(:user).order('created_at ASC')
   end

--- a/app/views/articles/_article.html.haml
+++ b/app/views/articles/_article.html.haml
@@ -21,8 +21,7 @@
       .chip-wrapper{style:'width:100%;height:37px'}
         = link_to user_path(article.user), class: 'base' do
           %i.link.material-icons face
-          = User.find(article.user_id.to_i).name
-          さんの投稿
+          %span #{article.user.name}さんの投稿
       .right-align
         = link_to root_path, class: 'btn btn-floating grey lighten-5 waves-effect waves-light' do
           %i.favorite.material-icons favorite_border

--- a/app/views/users/_user_info.html.haml
+++ b/app/views/users/_user_info.html.haml
@@ -1,5 +1,5 @@
 .card-wrap
-  - if params[:id].to_i == current_user.id
+  - if user_signed_in? && params[:id].to_i == current_user.id
     .user-edit
       = link_to 'プロフィール編集', edit_user_path(params[:id]), method: :get, remote: true, class: 'btn bg-pink'
   .card.no-shadow


### PR DESCRIPTION
# WHAT
・ログインしていない状態でユーザーページを見ようとするとエラーになるので、分岐の条件を設定する
・ユーザー画像を登録していないとマイページで何も表示されないので、デフォルトの画像が表示されるようにする。